### PR TITLE
add note about restarting the runner service after changing the .env file

### DIFF
--- a/content/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job.md
+++ b/content/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job.md
@@ -58,6 +58,9 @@ ACTIONS_RUNNER_HOOK_JOB_STARTED=/opt/runner/cleanup_script.sh
 > [!NOTE]
 > The script defined in `ACTIONS_RUNNER_HOOK_JOB_COMPLETED` is executed at the end of the job, before the job completes. This makes it unsuitable for use cases that may interrupt a runner, such as deleting the runner machine as part of an autoscaling implementation.
 
+> [!NOTE]
+> If the runner application is running as a service, it reads the `.env` file only when the service starts. So after creating or editing the `.env` file, you need to stop and restart the service.
+
 ## Troubleshooting
 
 ### Permission denied


### PR DESCRIPTION
…file

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Because I spent about half an hour scratching my head why my script defined in the `.env` file was not executed, until I had the idea to restart the runner service.  
I assumed that the runner read the file before each job run, IMO it's not obvious that it only happens after restarting.

IMO it's not obvious that the runner only reads the file after restarting, I assumed that it happens before each job run.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->


### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
